### PR TITLE
Add INPUT = CSV & generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 credentials.json
 token.json
 .env
+monthly.csv

--- a/README.md
+++ b/README.md
@@ -2,7 +2,28 @@
 
 # SETUP
 
-#### Google Calendar
+#### Input: CSV (NEW!)
+
+If you don't organize yourself using Google Calendar, now there is a new input method.
+
+First, generate a default `monthly.csv` with
+```bash
+$ ./csv-generator.js # it will try to skip all JAPANESE holidays (Sat + Sun too)
+File ./monthly.csv written.
+Review extra working or swapped days !!
+```
+
+Then ensure to modify your `.env` file with
+```yaml
+INPUT=csv
+...
+```
+
+And run it like the usage section. 
+CSV has only 1 argument, which is the filename (just in case you want to organize backups, etc.)
+
+
+#### Input: Google Calendar
 
 First you will need to create your own application (if you belong to my company, I can share my own `client_secret` with you).
 You can do it manually, going to https://console.developers.google.com/apis/dashboard, create a new project, enabling Google Calendar API and creating a set of credentials.
@@ -32,6 +53,7 @@ Example:
 
 Create a file named `.env` and add your credentials:
 ```yaml
+INPUT=calendar # or "csv"
 JOBCAN_USERNAME=whatever@moneytree.jp
 JOBCAN_PASSWORD=BliBliBli
 JOBCAN_STRATEGY=sum
@@ -79,5 +101,6 @@ Started with 2020-01-03 & id=1577977200^C
 
 - [x] JobCan strategies
 - [x] TimeZone
+- [x] Add multiple inputs (Google Calendar, CSV, ..)
+- [x] Manage Holidays (best-effort)
 - [ ] Tests
-- [ ] Manage Holidays (events are currently discarded)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Example:
 Create a file named `.env` and add your credentials:
 ```yaml
 INPUT=calendar # or "csv"
+HOLIDAY_ZONE=JP # https://github.com/commenthol/date-holidays/#supported-countries-states-regions
 JOBCAN_USERNAME=whatever@moneytree.jp
 JOBCAN_PASSWORD=BliBliBli
 JOBCAN_STRATEGY=sum
@@ -102,5 +103,5 @@ Started with 2020-01-03 & id=1577977200^C
 - [x] JobCan strategies
 - [x] TimeZone
 - [x] Add multiple inputs (Google Calendar, CSV, ..)
-- [x] Manage Holidays (best-effort)
+- [x] Manage Holidays (JP/AU/wherever)
 - [ ] Tests

--- a/csv-generator.js
+++ b/csv-generator.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+const moment = require('moment');
+const fs = require('fs').promises;
+const JapaneseHolidays = require('japanese-holidays');
+
+// defaults
+let filename = './monthly.csv';
+let year = moment().year();
+let month = moment().month(); // It seems more useful with previous month than current
+let clockin = '10:00';
+let clockout = '19:00';
+let breaktime = '01:00';
+
+
+// best effort!
+function isHoliday(date) {
+  return (['Sat', 'Sun'].indexOf(date.format('ddd')) !== -1)
+    || JapaneseHolidays.isHoliday(date.toDate());
+}
+
+
+async function main() {
+  let content = ['date,clockin,clockout,breaktime'];
+
+  let iterator = 1;
+  const lastDay = moment([year, month  - 1, 1]).endOf('month').date();
+
+  while (iterator < lastDay) {
+    const cursor = moment([year, month - 1, iterator]);
+
+    if (!isHoliday(cursor)) {
+      content.push([
+        cursor.format('YYYY-MM-DD'),
+        clockin,
+        clockout,
+        breaktime
+      ].join(','));
+    }
+
+    iterator += 1;
+  }
+
+  await fs.writeFile(filename, content.join("\n"));
+  console.log(`File ${filename} written.`);
+  console.log(`Review extra working or swapped days !!`);
+}
+
+
+main().catch(console.error);

--- a/index.js
+++ b/index.js
@@ -1,31 +1,11 @@
 require('dotenv').config();
 
-const moment = require('moment-timezone');
 const {askIfContinue} = require('./lib/ask.js');
-const calendar = new (require('./model/calendar.js'))();
 const jobcan = new (require('./model/jobcan.js'))();
 
 
-function input() {
-  let unit = 'week';
-  let timeMin = moment().subtract(1, unit).startOf(unit).toISOString();
-  let timeMax = moment().subtract(1, unit).endOf(unit).toISOString();
-
-  let myArgs = process.argv.slice(2);
-  if (myArgs[0]) timeMin = moment(myArgs[0]).toISOString();
-  if (myArgs[1]) timeMax = moment(myArgs[1]).toISOString();
-
-  return { timeMin, timeMax };
-}
-
-
 async function main() {
-  const { timeMin, timeMax } = input();
-
-  console.log(`With locale ${moment.locale()}, timezone ${moment().format('Z')}`);
-  console.log(`Search between ${timeMin} and ${timeMax}`);
-
-  const events = await calendar.getEventList(timeMin, timeMax);
+  const events = await require(`./input/${process.env.INPUT}.js`)();
 
   jobcan.display(events);
 

--- a/input/calendar.js
+++ b/input/calendar.js
@@ -1,0 +1,25 @@
+const moment = require('moment-timezone');
+const calendar = new (require('../model/calendar.js'))();
+
+
+function input() {
+  let unit = 'week';
+  let timeMin = moment().subtract(1, unit).startOf(unit).toISOString();
+  let timeMax = moment().subtract(1, unit).endOf(unit).toISOString();
+
+  let myArgs = process.argv.slice(2);
+  if (myArgs[0]) timeMin = moment(myArgs[0]).toISOString();
+  if (myArgs[1]) timeMax = moment(myArgs[1]).toISOString();
+
+  return { timeMin, timeMax };
+}
+
+
+module.exports = async function() {
+  const { timeMin, timeMax } = input();
+
+  console.log(`With locale ${moment.locale()}, timezone ${moment().format('Z')}`);
+  console.log(`Search between ${timeMin} and ${timeMax}`);
+
+  return await calendar.getEventList(timeMin, timeMax);
+};

--- a/input/csv.js
+++ b/input/csv.js
@@ -1,0 +1,22 @@
+const csv = new (require('../model/csv.js'))();
+const fs = require('fs').promises;
+
+function input() {
+  let filename = './monthly.csv';
+
+  let myArgs = process.argv.slice(2);
+  if (myArgs[0]) filename = String(myArgs[0]);
+
+  return { filename };
+}
+
+
+module.exports = async function() {
+  const { filename } = input();
+
+  console.log(`Reading from ${filename}`);
+
+  const content = await fs.readFile(filename);
+
+  return csv.extractEvents(content);
+};

--- a/model/csv.js
+++ b/model/csv.js
@@ -1,0 +1,37 @@
+const parse = require('csv-parse/lib/sync');
+const moment = require('moment-timezone');
+
+class Csv {
+
+  asCompactedEvent(event) {
+    return {
+      date: event.date,
+      duration: (moment(`2000-01-01 ${event.clockout}`) - moment(`2000-01-01 ${event.clockin}`)) / 1000 / 60,
+      clockin: event.clockin,
+      clockout: event.clockout,
+      breaktime: event.breaktime,
+      year: moment(event.date).format('YYYY'),
+      month: moment(event.date).format('MM'),
+      day: moment(event.date).format('DD')
+    };
+  }
+
+  groupByDate(iterator, current) {
+    // no duplicates, right?
+    iterator[current.date] = current;
+    return iterator;
+  }
+
+  extractEvents(content) {
+    const records = parse(content, {
+      columns: true,
+      trim: true,
+      skip_empty_lines: true
+    });
+
+    return records.map(this.asCompactedEvent)
+      .reduce(this.groupByDate, {});
+  }
+}
+
+module.exports = Csv;

--- a/model/google.js
+++ b/model/google.js
@@ -7,8 +7,8 @@ const {google} = require('googleapis');
 
 class Google {
   constructor() {
-    this.CREDENTIALS_PATH = 'credentials.json';
     this.TOKEN_PATH = 'token.json';
+    this.CREDENTIALS_PATH = 'credentials.json';
     this.SCOPES = ['https://www.googleapis.com/auth/calendar.readonly'];
     this.OFFLINE = 'offline';
   }

--- a/model/jobcan.js
+++ b/model/jobcan.js
@@ -4,7 +4,17 @@ const moment = require('moment-timezone');
 const {openBrowser, goto, write, click, button, closeBrowser,
   $, evaluate, near, textBox, dropDown, text, clear} = require('taiko');
 
-
+/*
+ events = {
+  duration: 8*60
+  clockin: '10:00'
+  clockout: '19:00'
+  breaktime: '1:00'
+  year: 2020
+  month: 01
+  day: 01
+ }
+ */
 class Jobcan {
   display(events) {
     let dduration = 0;

--- a/model/jobcan.js
+++ b/model/jobcan.js
@@ -1,6 +1,7 @@
 const colors = require('colors/safe');
 const pad = require('pad-left');
 const moment = require('moment-timezone');
+const JapaneseHolidays = require('japanese-holidays');
 const {openBrowser, goto, write, click, button, closeBrowser,
   $, evaluate, near, textBox, dropDown, text, clear} = require('taiko');
 
@@ -10,12 +11,18 @@ const {openBrowser, goto, write, click, button, closeBrowser,
   clockin: '10:00'
   clockout: '19:00'
   breaktime: '1:00'
-  year: 2020
-  month: 01
-  day: 01
+  year: '2020'
+  month: '01'
+  day: '01'
  }
  */
 class Jobcan {
+  // best effort!
+  isHoliday(date) {
+    return (['Sat', 'Sun'].indexOf(date.format('ddd')) !== -1)
+      || JapaneseHolidays.isHoliday(date.toDate());
+  }
+
   display(events) {
     let dduration = 0;
     let weekday = 0;
@@ -37,8 +44,7 @@ class Jobcan {
       ]
         .join("\t");
 
-      // TODO moment-holiday ??
-      if (['Sat', 'Sun'].indexOf(moment(key).format('ddd')) !== -1) {
+      if (this.isHoliday(moment(key))) {
         console.log(colors.grey(line));
       } else {
         console.log(line);

--- a/model/jobcan.js
+++ b/model/jobcan.js
@@ -1,7 +1,7 @@
 const colors = require('colors/safe');
 const pad = require('pad-left');
 const moment = require('moment-timezone');
-const JapaneseHolidays = require('japanese-holidays');
+const holidays = new (require('date-holidays'))();
 const {openBrowser, goto, write, click, button, closeBrowser,
   $, evaluate, near, textBox, dropDown, text, clear} = require('taiko');
 
@@ -17,10 +17,14 @@ const {openBrowser, goto, write, click, button, closeBrowser,
  }
  */
 class Jobcan {
+  constructor() {
+    holidays.init(process.env.HOLIDAY_ZONE || 'JP')
+  }
+
   // best effort!
   isHoliday(date) {
     return (['Sat', 'Sun'].indexOf(date.format('ddd')) !== -1)
-      || JapaneseHolidays.isHoliday(date.toDate());
+      || holidays.isHoliday(date.toDate());
   }
 
   display(events) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,14 @@
         "uri-js": "^4.2.2"
       }
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "arrify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
@@ -50,6 +58,11 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
       "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA=="
+    },
+    "astronomia": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/astronomia/-/astronomia-2.1.1.tgz",
+      "integrity": "sha512-y8SySXRHpsUguSeEvsHjlOJsSgO/qAANwpWGOOue68wYwjPVj2bwogdtwJyNRHULET13rgH6Wp+a2lNP1Bmteg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -98,6 +111,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "caldate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/caldate/-/caldate-1.1.0.tgz",
+      "integrity": "sha512-Z8AF+9Ha/40UBmZXJbb0qQNx6Djv1BySw0o7kcBKuzKmmqK/nUCjW+ez/6fFqWZglPgUXiy0n/zGMncYpKXtmQ==",
+      "requires": {
+        "moment-timezone": "^0.5.27"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -165,6 +186,53 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "date-bengali-revised": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/date-bengali-revised/-/date-bengali-revised-1.0.2.tgz",
+      "integrity": "sha512-HehC0Kcjz+wgTSXAA/ei/Y4QPEg1nCYeZdrBl/o/o1B+iPycvipeTIhff9nXtQUY17nrXLunvOWTzqbR490m2w=="
+    },
+    "date-chinese": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/date-chinese/-/date-chinese-1.0.7.tgz",
+      "integrity": "sha512-Dx1VG/mSST1yYqZvJvBWxvdDKTlmerZWXopiaPmVKeVFNhTZ20RvMrexg4FPFrCygPrgqTDtB2bEcwFcRoO2ww==",
+      "requires": {
+        "astronomia": "^2.1.1"
+      }
+    },
+    "date-easter": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/date-easter/-/date-easter-0.2.5.tgz",
+      "integrity": "sha512-pMvZSqQgPBqnUQEHhRMy7f8Dk3KYY/NPFMFHGK4mU+xM1+SX+zc9IoQMcNtS3HuJjCn3mp0GQwBzsZXz3Thjww=="
+    },
+    "date-holidays": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-1.4.14.tgz",
+      "integrity": "sha512-M3gbpz1xF3GSMCJdkx88LOwIyAGfh6b22lOh+G+Hjo73haukbH+VDZZYIEC81M0jy6gHZU65yWWf3iMJUHRlFQ==",
+      "requires": {
+        "date-holidays-parser": "^1.4.2",
+        "js-yaml": "^3.13.1",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "prepin": "^1.0.3"
+      }
+    },
+    "date-holidays-parser": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/date-holidays-parser/-/date-holidays-parser-1.4.2.tgz",
+      "integrity": "sha512-7ty4DoAO1DqSmxKLDkstrNMQId8LBrw98gXXRWC79oua+hyC0suqpzUGFd7269VqnfeRo0SR+xwQeQarjEziPQ==",
+      "requires": {
+        "astronomia": "^2.1.1",
+        "caldate": "^1.1.0",
+        "date-bengali-revised": "^1.0.2",
+        "date-chinese": "^1.0.7",
+        "date-easter": "^0.2.5",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.omit": "^4.5.0",
+        "lodash.set": "^4.3.2",
+        "moment-timezone": "^0.5.27"
       }
     },
     "debug": {
@@ -444,10 +512,14 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
-    "japanese-holidays": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/japanese-holidays/-/japanese-holidays-1.0.9.tgz",
-      "integrity": "sha512-djWao0cXHo8kJnQZWiBDyOzFIV+Iht+PU3X5ghLLSYliHEgRCxeGpH3+HH+ZTWaY7ZQ/reujGBL+daV2xrW9bg=="
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -515,6 +587,31 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -558,14 +655,6 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-    },
-    "moment-holiday": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/moment-holiday/-/moment-holiday-1.5.1.tgz",
-      "integrity": "sha1-s3k5xSuRmwL/FC11QDfud2zUBUc=",
-      "requires": {
-        "moment": ">=2.0.0"
-      }
     },
     "moment-timezone": {
       "version": "0.5.27",
@@ -612,6 +701,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "prepin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/prepin/-/prepin-1.0.3.tgz",
+      "integrity": "sha512-0XL2hreherEEvUy0fiaGEfN/ioXFV+JpImqIzQjxk6iBg4jQ2ARKqvC4+BmRD8w/pnpD+lbxvh0Ub+z7yBEjvA=="
     },
     "private": {
       "version": "0.1.8",
@@ -733,6 +827,11 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,6 +154,11 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "csv-parse": {
+      "version": "4.8.8",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.8.tgz",
+      "integrity": "sha512-Kv3Ilz2GV58dOoHBXRCTF8ijxlLjl80bG3d67XPI6DNqffb3AnbPbKr/WvCUMJq5V0AZYi6sukOaOQAVpfuVbg=="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -438,6 +443,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "japanese-holidays": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/japanese-holidays/-/japanese-holidays-1.0.9.tgz",
+      "integrity": "sha512-djWao0cXHo8kJnQZWiBDyOzFIV+Iht+PU3X5ghLLSYliHEgRCxeGpH3+HH+ZTWaY7ZQ/reujGBL+daV2xrW9bg=="
     },
     "jsbn": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,10 @@
   "dependencies": {
     "colors": "1.4.0",
     "csv-parse": "4.8.8",
+    "date-holidays": "1.4.14",
     "dotenv": "8.2.0",
     "googleapis": "46.0.0",
-    "japanese-holidays": "1.0.9",
     "moment": "2.24.0",
-    "moment-holiday": "1.5.1",
     "moment-timezone": "0.5.27",
     "pad-left": "2.1.0",
     "request": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar2jobcan",
   "version": "1.0.0",
-  "description": "Sync Jobcan with Google Calendar",
+  "description": "Sync Jobcan with Google Calendar or CSV",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0"
@@ -14,8 +14,10 @@
   "license": "MIT",
   "dependencies": {
     "colors": "1.4.0",
+    "csv-parse": "4.8.8",
     "dotenv": "8.2.0",
     "googleapis": "46.0.0",
+    "japanese-holidays": "1.0.9",
     "moment": "2.24.0",
     "moment-holiday": "1.5.1",
     "moment-timezone": "0.5.27",


### PR DESCRIPTION
# Summary
This PR adds CSV input aside of Google Calendar. There is also a generator and (customizable) national holidays are detected..

```
$ npm i
$ ./csv-generator.js
#  Add  `INPUT=csv` in your .env file  (or INPUT=calendar)
# Add `HOLIDAY_ZONE=JP` in your .env file (or INPUT=AU)
$ node .
```

Enjoy!!